### PR TITLE
(SIMP-315) Update to work with the new PW Overlay

### DIFF
--- a/build/pupmod-openldap.spec
+++ b/build/pupmod-openldap.spec
@@ -1,7 +1,7 @@
 Summary: OpenLDAP Puppet Module
 Name: pupmod-openldap
 Version: 4.1.1
-Release: 1
+Release: 2
 License: Apache License, Version 2.0
 Group: Applications/System
 Source: %{name}-%{version}-%{release}.tar.gz
@@ -66,6 +66,12 @@ fi
 # Post uninstall stuff
 
 %changelog
+* Thu Jul 30 2015 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.1.1-2
+- Made the password policy overlay align with the latest SIMP build of the
+  plugin.
+- This means that you *must* have version simp-ppolicy-check-password-2.4.39-0
+  or later available to the system being configured.
+
 * Sat May 16 2015 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.1.1-1
 - More closely align with the published STIG guidelines.
 

--- a/manifests/slapo/ppolicy.pp
+++ b/manifests/slapo/ppolicy.pp
@@ -74,7 +74,12 @@ class openldap::slapo::ppolicy (
 ) {
     include 'openldap::server::dynamic_includes'
 
-    $check_password = versioncmp($::lsbmajdistrelease,'7') ? {
+    $_simp_version = simp_version() ? {
+      /undefined/ => '0',
+      default     => simp_version()
+    }
+
+    $_check_password = versioncmp($_simp_version,'4.2.0') ? {
       '-1' => 'check_password',
       default => 'simp_check_password'
     }
@@ -86,7 +91,7 @@ class openldap::slapo::ppolicy (
         content => template('openldap/slapo/ppolicy.erb')
     }
 
-    file { "/etc/openldap/${check_password}.conf":
+    file { "/etc/openldap/${_check_password}.conf":
       owner   => 'root',
       group   => 'ldap',
       mode    => '0640',

--- a/spec/classes/slapo/ppolicy_spec.rb
+++ b/spec/classes/slapo/ppolicy_spec.rb
@@ -43,11 +43,7 @@ describe 'openldap::slapo::ppolicy' do
     )}
 
     it {
-      if ['RedHat','CentOS'].include?(facts[:operatingsystem]) and facts[:operatingsystemmajrelease] < "7"
-        conf_name = 'check_password.conf'
-      else
-        conf_name = 'simp_check_password.conf'
-      end
+      conf_name = 'simp_check_password.conf'
 
       should create_file("/etc/openldap/#{conf_name}").with({
         :group    => 'ldap',


### PR DESCRIPTION
- Made the password policy overlay align with the latest SIMP build of
  the plugin.
- This means that you _must_ have version
  simp-ppolicy-check-password-2.4.39-0 or later available to the system
  being configured.

SIMP-315 #close #comment Be careful to update the Changelog to reflect that users need simp-ppolicy-check-password-2.4.39-0
