### PR TITLE
(SIMP-315) Update to work with the new PW Overlay

### DIFF
--- a/build/pupmod-openldap.spec
+++ b/build/pupmod-openldap.spec
@@ -1,7 +1,7 @@
 Summary: OpenLDAP Puppet Module
 Name: pupmod-openldap
 Version: 4.1.1
-Release: 1
+Release: 2
 License: Apache License, Version 2.0
 Group: Applications/System
 Source: %{name}-%{version}-%{release}.tar.gz
@@ -66,6 +66,14 @@ fi
 # Post uninstall stuff
 
 %changelog
+* Thu Jul 30 2015 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.1.1-2
+- The Password Policy overlay was getting loaded into the default.ldif even if
+  you didn't want to use it. This has been fixed.
+- Made the password policy overlay align with the latest SIMP build of the
+  plugin.
+- This means that you *must* have version simp-ppolicy-check-password-2.4.39-0
+  or later available to the system being configured.
+
 * Sat May 16 2015 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.1.1-1
 - More closely align with the published STIG guidelines.
 

--- a/manifests/server/conf.pp
+++ b/manifests/server/conf.pp
@@ -419,6 +419,7 @@ class openldap::server::conf (
     notify  => Service[$openldap::server::slapd_svc]
   }
 
+  $_simp_ppolicy_check_password = $::openldap::slapo::ppolicy::check_password
   file { '/etc/openldap/default.ldif':
     ensure  => 'file',
     owner   => 'root',

--- a/manifests/slapo/ppolicy.pp
+++ b/manifests/slapo/ppolicy.pp
@@ -74,7 +74,14 @@ class openldap::slapo::ppolicy (
 ) {
     include 'openldap::server::dynamic_includes'
 
-    $check_password = versioncmp($::lsbmajdistrelease,'7') ? {
+    $_simp_version = simp_version() ? {
+      /undefined/ => '0',
+      default     => simp_version()
+    }
+
+    # This is used by the default template.
+    # This should be cleaned up all around.
+    $check_password = versioncmp($_simp_version,'4.2.0') ? {
       '-1' => 'check_password',
       default => 'simp_check_password'
     }

--- a/spec/classes/server/conf_spec.rb
+++ b/spec/classes/server/conf_spec.rb
@@ -45,7 +45,7 @@ describe 'openldap::server::conf' do
     it { should compile.with_all_deps }
     it { should create_file('/etc/openldap/DB_CONFIG').with_content(/set_data_dir/) }
     it { should create_file('/etc/openldap/default.ldif').with_content(/dn: #{params[:suffix]}/) }
-    it { should create_file('/etc/openldap/default.ldif').with_content(/pwdCheckModule: .*check_password.so/) }
+    it { should create_file('/etc/openldap/default.ldif').with_content(/pwdCheckModule: .*simp_check_password.so/) }
     it {
       if ['RedHat','CentOS'].include?(facts[:operatingsystem]) and facts[:operatingsystemmajrelease] < "7"
       then

--- a/spec/classes/slapo/ppolicy_spec.rb
+++ b/spec/classes/slapo/ppolicy_spec.rb
@@ -43,11 +43,7 @@ describe 'openldap::slapo::ppolicy' do
     )}
 
     it {
-      if ['RedHat','CentOS'].include?(facts[:operatingsystem]) and facts[:operatingsystemmajrelease] < "7"
-        conf_name = 'check_password.conf'
-      else
-        conf_name = 'simp_check_password.conf'
-      end
+      conf_name = 'simp_check_password.conf'
 
       should create_file("/etc/openldap/#{conf_name}").with({
         :group    => 'ldap',

--- a/templates/etc/openldap/default.ldif.erb
+++ b/templates/etc/openldap/default.ldif.erb
@@ -118,7 +118,9 @@ pwdFailureCountInterval: 900
 pwdMustChange: TRUE
 pwdAllowUserChange: TRUE
 pwdSafeModify: FALSE
-pwdCheckModule: <%= scope.lookupvar('::openldap::slapo::ppolicy::check_pmassword') %>.so
+<% if @_simp_ppolicy_check_password -%>
+pwdCheckModule: <%= @_simp_ppolicy_check_password %>.so
+<% end -%>
 
 # This is for "special" accounts like hostAuth and LDAPSync
 dn: cn=noExpire_noLockout,ou=pwpolicies,<%= @suffix %>
@@ -142,4 +144,6 @@ pwdFailureCountInterval: 900
 pwdMustChange: FALSE
 pwdAllowUserChange: FALSE
 pwdSafeModify: FALSE
-pwdCheckModule: <%= scope.lookupvar('::openldap::slapo::ppolicy::check_password') %>.so
+<% if @_simp_ppolicy_check_password -%>
+pwdCheckModule: <%= @_simp_ppolicy_check_password %>.so
+<% end -%>


### PR DESCRIPTION
- The Password Policy overlay was getting loaded into the default.ldif
  even if you didn't want to use it. This has been fixed.
- Made the password policy overlay align with the latest SIMP build of
  the plugin.
- This means that you *must* have version
  simp-ppolicy-check-password-2.4.39-0 or later available to the system
  being configured.

SIMP-315 #close #comment Be careful to update the Changelog to reflect that users need simp-ppolicy-check-password-2.4.39-0

Change-Id: Ic89bd343b300ae29bfefbab5b297664dd5a282ea