### PR TITLE
(SIMP-17) Include openldap::pam in init.pp

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -44,6 +44,9 @@ class openldap (
   $ldap_uri = hiera('ldap::uri'),
   $is_server = false,
 ) {
+
+  include 'openldap::pam'
+
   if $is_server { include 'openldap::server' }
 
   validate_bool($is_server)


### PR DESCRIPTION
Added openldap::pam to init.pp to compensate for removing it from the
base SIMP distribution in simp-core/../simp_boostrap.yaml.

SIMP-17 #comment Included openldap::pam in openldap/init.pp