### PR TITLE
(SIMP-609) Update pwdGraceAuthNLimit to -1

### DIFF
--- a/build/pupmod-openldap.spec
+++ b/build/pupmod-openldap.spec
@@ -1,7 +1,7 @@
 Summary: OpenLDAP Puppet Module
 Name: pupmod-openldap
 Version: 4.1.1
-Release: 3
+Release: 4
 License: Apache License, Version 2.0
 Group: Applications/System
 Source: %{name}-%{version}-%{release}.tar.gz
@@ -23,7 +23,7 @@ Buildarch: noarch
 Requires: simp-bootstrap >= 4.2.0
 Obsoletes: pupmod-openldap-test
 
-Prefix: /etc/puppet/environments/simp/modules
+Prefix: %{_sysconfdir}/puppet/environments/simp/modules
 
 %description
 This Puppet module provides the capability to configure OpenLDAP servers and
@@ -59,13 +59,17 @@ mkdir -p %{buildroot}/%{prefix}/openldap
 #!/bin/sh
 
 if [ -d %{prefix}/openldap/plugins ]; then
-  /bin/mv %{prefix}/openldap/plugins %{prefix}/openldap/plugins.bak
+  mv %{prefix}/openldap/plugins %{prefix}/openldap/plugins.bak
 fi
 
 %postun
 # Post uninstall stuff
 
 %changelog
+* Mon Nov 09 2015 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.1.1-4
+- Changed pwdGraceAuthnLimit to '-1' to allow users to change their passwords
+  post expiry.
+
 * Thu Jul 30 2015 Kendall Moore <kmoore@keywcorp.com> - 4.1.1-3
 - Updated to use the new rsyslog module.
 

--- a/templates/etc/openldap/default.ldif.erb
+++ b/templates/etc/openldap/default.ldif.erb
@@ -110,7 +110,7 @@ pwdInHistory: 24
 pwdCheckQuality: 2
 pwdMinLength: 14
 pwdExpireWarning: 1209600
-pwdGraceAuthnLimit: 0
+pwdGraceAuthNLimit: -1
 pwdLockout: TRUE
 pwdLockoutDuration: 900
 pwdMaxFailure: 5
@@ -136,7 +136,7 @@ pwdInHistory: 24
 pwdCheckQuality: 2
 pwdMinLength: 14
 pwdExpireWarning: 0
-pwdGraceAuthnLimit: 0
+pwdGraceAuthNLimit: -1
 pwdLockout: FALSE
 pwdLockoutDuration: 900
 pwdMaxFailure: 5


### PR DESCRIPTION
The value of '0' for pwdGraceAuthNLimit did not allow any password
changes once the user's account had expired.

This was changed to '-1' to (usually) allow for unlimited numbers of
password retries as this is generally in line with the core operating
system.

SIMP-609 #close