### PR TITLE
(SIMP-645) Update to handle default sssd in 7

### DIFF
--- a/build/pupmod-openldap.spec
+++ b/build/pupmod-openldap.spec
@@ -68,6 +68,7 @@ fi
 %changelog
 * Thu Nov 12 2015 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.1.1-6
 - Replaced all 'lsb*' facts with 'operatingsystem*' facts.
+- Updated to use SSSD by default on EL<7.
 
 * Mon Nov 09 2015 Chris Tessmer <chris.tessmer@onypoint.com> - 4.1.1-5
 - migration to simplib and simpcat (lib/ only)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -19,6 +19,25 @@
 # Default: false
 #   Set this if you want to create an OpenLDAP server on your node.
 #
+# [*use_nscd*]
+# Type: Boolean
+# Default: true
+#   Only appiles to *client* systems
+#
+#   Whether or not to use NSCD in the installation instead of SSSD. If
+#   '$use_sssd = true' then this will not be referenced.
+#
+# [*use_sssd*]
+# Type: Boolean
+# Default: false if EL<7, true otherwise
+#   Only appiles to *client* systems
+#
+#   Whether or not to use SSSD in the installation.
+#   There are issues where SSSD will allow a login, even if the user's password
+#   has expire, if the user has a valid SSH key. However, in EL7+, there are
+#   issues with nscd and nslcd which can lock users our of the system when
+#   using LDAP.
+#
 # == Hiera Variables
 #
 # [*ldap::base_dn*]
@@ -43,7 +62,9 @@ class openldap (
   $ldap_master = hiera('ldap::master',''),
   $ldap_uri = hiera('ldap::uri'),
   $is_server = false,
-) {
+  $use_nscd = $::openldap::params::use_nscd,
+  $use_sssd = $::openldap::params::use_sssd
+) inherits ::openldap::params {
   if $is_server { include 'openldap::server' }
 
   validate_bool($is_server)

--- a/manifests/pam.pp
+++ b/manifests/pam.pp
@@ -130,9 +130,9 @@ class openldap::pam (
     'hsqldb','radvd','apache','tomcat'
   ],
   $use_auditd = true,
-  $use_nscd = hiera('use_nscd',true),
-  $use_sssd = hiera('use_sssd',false)
-) {
+  $use_nscd = $::openldap::use_nscd,
+  $use_sssd = $::openldap::use_sssd
+) inherits ::openldap {
 
   $ldap_conf = '/etc/pam_ldap.conf'
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,0 +1,36 @@
+# == Class: openldap::params
+#
+# A set of defaults for the 'simp' namespace
+#
+# $use_sssd
+# Default: false on EL<7, true otherwise
+#   There are issues with nscd and nslcd on EL7+ which can result in users
+#   being locked out of the system. SSSD contains a bug which will allow users
+#   with a valid SSH key to bypass the password lockout as returned by LDAP but
+#   this can be worked around much more easily than the workaround for the nscd
+#   issues which significantly weaken your security posture.
+class openldap::params {
+  if $::operatingsystem in ['RedHat','CentOS'] {
+    if versioncmp($::operatingsystemmajrelease,'7') < 0 {
+      $_use_sssd = false
+      $_use_nscd = true
+    }
+    else {
+      $_use_sssd = true
+      $_use_nscd = false
+    }
+
+    $use_sssd = defined('$::use_sssd') ? {
+      true => $::use_sssd,
+      default => hiera('use_sssd',$_use_sssd)
+    }
+
+    $use_nscd = defined('$::use_nscd') ? {
+      true => $::use_nscd,
+      default => hiera('use_nscd',$_use_nscd)
+    }
+  }
+  else {
+    fail("${::operatingsystem} not yet supported by ${::module_name}")
+  }
+}


### PR DESCRIPTION
EL7 does not currently play well with nscd and needs to be moved to sssd
by default.

This change ensures that this happens properly.

This probably needs to be combined with the work in the 'simp' module in
the future.

SIMP-645 #close
SIMP-631 #comment Update for OpenLDAP defaults