### PR TITLE
(SIMP-686) Update default.ldif

### DIFF
--- a/manifests/server/conf.pp
+++ b/manifests/server/conf.pp
@@ -475,7 +475,8 @@ class openldap::server::conf (
   validate_bool($use_tls)
   validate_bool($enable_iptables)
 
-  include 'openldap::server'
+  include '::openldap::server'
+  include '::openldap::server::conf::default_ldif'
 
   if $use_tls {
     pki::copy { '/etc/openldap':
@@ -524,15 +525,6 @@ class openldap::server::conf (
     mode    => '0640',
     content => template('openldap/etc/openldap/DB_CONFIG.erb'),
     notify  => Service[$openldap::server::slapd_svc]
-  }
-
-  $_simp_ppolicy_check_password = $::openldap::slapo::ppolicy::check_password
-  file { '/etc/openldap/default.ldif':
-    ensure  => 'file',
-    owner   => 'root',
-    group   => 'ldap',
-    mode    => '0640',
-    content => template('openldap/etc/openldap/default.ldif.erb'),
   }
 
   if ($::operatingsystem in ['RedHat','CentOS']) and ($::operatingsystemmajrelease > '6') {

--- a/manifests/server/conf/default_ldif.pp
+++ b/manifests/server/conf/default_ldif.pp
@@ -1,0 +1,54 @@
+#
+# == Class: openldap::server::conf::default_ldif
+#
+# This allows for the modification of the default LDIF entries in
+# /etc/openldap/default.ldif. It will *not* modify any active values in a
+# running LDAP server.
+#
+# == Authors:
+#
+# * Trevor Vaughan <tvaughan@onyxpoint.com>
+#
+class openldap::server::conf::default_ldif (
+  $ppolicy_pwd_min_age = '86400',
+  $ppolicy_pwd_max_age = '15552000',
+  $ppolicy_pwd_in_history = '24',
+  $ppolicy_pwd_check_quality = '2',
+  $ppolicy_pwd_min_length = '14',
+  $ppolicy_pwd_expire_warning = '1209600',
+  $ppolicy_pwd_grace_authn_limit = '-1',
+  $ppolicy_pwd_lockout = true,
+  $ppolicy_pwd_lockout_duration = '900',
+  $ppolicy_pwd_max_failure = '5',
+  $ppolicy_pwd_failure_count_interval = '900',
+  $ppolicy_pwd_must_change = true,
+  $ppolicy_pwd_allow_user_change = true,
+  $ppolicy_pwd_safe_modify = false
+) {
+  assert_private()
+
+  validate_integer($ppolicy_pwd_min_age)
+  validate_integer($ppolicy_pwd_max_age)
+  validate_integer($ppolicy_pwd_in_history)
+  validate_integer($ppolicy_pwd_in_history)
+  validate_integer($ppolicy_pwd_check_quality)
+  validate_integer($ppolicy_pwd_min_length)
+  validate_integer($ppolicy_pwd_expire_warning)
+  validate_integer($ppolicy_pwd_grace_authn_limit)
+  validate_bool($ppolicy_pwd_lockout)
+  validate_integer($ppolicy_pwd_lockout_duration)
+  validate_integer($ppolicy_pwd_max_failure)
+  validate_integer($ppolicy_pwd_failure_count_interval)
+  validate_bool($ppolicy_pwd_must_change)
+  validate_bool($ppolicy_pwd_allow_user_change)
+  validate_bool($ppolicy_pwd_safe_modify)
+
+  $_simp_ppolicy_check_password = $::openldap::slapo::ppolicy::check_password
+  file { '/etc/openldap/default.ldif':
+    ensure  => 'file',
+    owner   => 'root',
+    group   => 'ldap',
+    mode    => '0640',
+    content => template('openldap/etc/openldap/default.ldif.erb'),
+  }
+}

--- a/templates/etc/openldap/default.ldif.erb
+++ b/templates/etc/openldap/default.ldif.erb
@@ -104,21 +104,25 @@ objectClass: pwdPolicy
 objectClass: pwdPolicyChecker
 cn: default
 pwdAttribute: userPassword
-pwdMinAge: 86400
-pwdMaxAge: 15552000
-pwdInHistory: 24
-pwdCheckQuality: 2
-pwdMinLength: 14
-pwdExpireWarning: 1209600
-pwdGraceAuthNLimit: -1
-pwdLockout: TRUE
-pwdLockoutDuration: 900
-pwdMaxFailure: 5
-pwdFailureCountInterval: 900
-pwdMustChange: TRUE
-pwdAllowUserChange: TRUE
-pwdSafeModify: FALSE
-<% if @_simp_ppolicy_check_password -%>
+pwdMinAge: <%= @ppolicy_pwd_min_age %>
+pwdMaxAge: <%= @ppolicy_pwd_max_age %>
+pwdInHistory: <%= @ppolicy_pwd_in_history %>
+<% if @_simp_ppolicy_check_password && !"#{@_simp_ppolicy_check_password}".empty? -%>
+pwdCheckQuality: <%= @ppolicy_pwd_check_quality %>
+<% else -%>
+pwdCheckQuality: 0
+<% end -%>
+pwdMinLength: <%= @pwd_min_length %>
+pwdExpireWarning: <%= @pwd_expire_warning %>
+pwdGraceAuthNLimit: <%= @pwd_grace_authn_limit %>
+pwdLockout: <%= @pwd_lockout.to_s.upcase %>
+pwdLockoutDuration: <%= @pwd_lockout_duration %>
+pwdMaxFailure: <%= @pwd_max_failure %>
+pwdFailureCountInterval: <%= @pwd_failure_count_interval %>
+pwdMustChange: <%= @pwd_must_change.to_s.upcase %>
+pwdAllowUserChange: <%= @pwd_allow_user_change.to_s.upcase %>
+pwdSafeModify: <%= @pwd_safe_modify.to_s.upcase %>
+<% if @_simp_ppolicy_check_password && !"#{@_simp_ppolicy_check_password}".empty? -%>
 pwdCheckModule: <%= @_simp_ppolicy_check_password %>.so
 <% end -%>
 


### PR DESCRIPTION
The default.ldif template has been updated to provide the capability to
modify the password setting defaults.

This will _not_ affect the running LDAP server.

SIMP-686 #close
