### PR TITLE
(SIMP-904) Added further nslcd configuration capabilities

### DIFF
--- a/build/pupmod-openldap.spec
+++ b/build/pupmod-openldap.spec
@@ -1,6 +1,6 @@
 Summary: OpenLDAP Puppet Module
 Name: pupmod-openldap
-Version: 4.1.3
+Version: 4.1.4
 Release: 0
 License: Apache License, Version 2.0
 Group: Applications/System
@@ -63,6 +63,14 @@ mkdir -p %{buildroot}/%{prefix}/openldap
 # Post uninstall stuff
 
 %changelog
+* Sat Mar 26 2016 Nick Markowski <nmarkowski@keywcorp.com> - 4.1.4-0
+- nslcd group and user are ensured.
+- nslcd uid and gid default to 65 (nslcd). nslcd is no longer in the ldap group.
+- Created an nslcd conf dir for convenient cert location.  Defaults to /etc/nslcd.d.
+  If use_simp_pki is true, pki::copy copies the system certs here.
+- nslcd.conf tls options now have proper defaults. Fixed syntax errors in nslcd.conf
+  and pam_ldap.conf
+
 * Wed Mar 23 2016 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.1.3-0
 - Added an `openldap::server::service` class for external profiles that need to
   restart the service without triggering unnecessary side effects.

--- a/manifests/pam.pp
+++ b/manifests/pam.pp
@@ -21,6 +21,21 @@
 #
 #   If this is left empty, it will default to ALLLOCAL.
 #
+# [*nslcd_conf_dir*]
+# Type: String (absolute path)
+# Default: /etc/nslcd.d
+#   Directory which contains the nslcd pki certs.
+#
+# [*nslcd_uid*]
+# Type: Integer
+# Default: 65
+#   UID of the nslcd user.
+#
+# [*nslcd_gid*]
+# Type: Integer
+# Default: 65
+#   GID of the nslcd group.
+#
 # [*use_auditd*]
 # Type: Boolean
 # Default: true
@@ -129,6 +144,9 @@ class openldap::pam (
     'clam','nfsnobody','rpm','nslcd','avahi','gdm','rtkit','pulse',
     'hsqldb','radvd','apache','tomcat'
   ],
+  $nslcd_conf_dir = '/etc/nslcd.d',
+  $nslcd_uid      = '65',
+  $nslcd_gid      = '65',
   $use_auditd = true,
   $use_nscd = $::openldap::use_nscd,
   $use_sssd = $::openldap::use_sssd,
@@ -207,6 +225,9 @@ class openldap::pam (
   if !empty($tls_key) { validate_absolute_path($tls_key) }
   validate_bool($tls_randfile)
   validate_integer($threads)
+  validate_absolute_path($nslcd_conf_dir)
+  validate_integer($nslcd_uid)
+  validate_integer($nslcd_gid)
 
   compliance_map()
 
@@ -215,28 +236,28 @@ class openldap::pam (
   }
 
   if empty($tls_cert) and $use_simp_pki {
-    $_tls_cert = $::pki::public_key
+    $_tls_cert = "${nslcd_conf_dir}/pki/public/${::fqdn}.pub"
   }
   else {
     $_tls_cert = $tls_cert
   }
 
   if empty($tls_key) and $use_simp_pki {
-    $_tls_key = $::pki::private_key
+    $_tls_key = "${nslcd_conf_dir}/pki/private/${::fqdn}.pem"
   }
   else {
     $_tls_key = $tls_key
   }
 
   if empty($tls_cacertdir) and $use_simp_pki {
-    $_tls_cacertdir = $::pki::cacerts
+    $_tls_cacertdir = "${nslcd_conf_dir}/pki/cacerts"
   }
   else {
     $_tls_cacertdir = $tls_cacertdir
   }
 
   if empty($tls_cacertfile) and $use_simp_pki {
-    $_tls_cacertfile = $::pki::cacerts
+    $_tls_cacertfile = "${nslcd_conf_dir}/pki/cacerts/cacerts.pem"
   }
   else {
     $_tls_cacertfile = $tls_cacertfile
@@ -298,6 +319,27 @@ class openldap::pam (
       }
     }
 
+    group { 'nslcd_group':
+      name   => 'nslcd',
+      ensure => 'present',
+      gid    => $nslcd_gid
+    }
+
+    user { 'nslcd_user':
+      name  => 'nslcd',
+      uid   => $nslcd_uid,
+      gid   => $nslcd_gid,
+      require => Group['nslcd_group']
+    }
+
+    file { $nslcd_conf_dir:
+      ensure => 'directory',
+      mode   => '0750',
+      owner  => 'root',
+      group  => 'nslcd',
+      require => User['nslcd_user']
+    }
+
     file { '/etc/nslcd.conf':
       ensure  => 'file',
       owner   => 'root',
@@ -315,7 +357,11 @@ class openldap::pam (
       ensure     => 'running',
       enable     => true,
       hasstatus  => true,
-      hasrestart => true
+      hasrestart => true,
+      require    => [
+        File['/etc/nslcd.conf'],
+        File[$nslcd_conf_dir]
+      ]
     }
 
     if $ssl {
@@ -323,6 +369,12 @@ class openldap::pam (
     }
 
     if $use_simp_pki {
+      pki::copy { $nslcd_conf_dir:
+        group  => 'nslcd',
+        notify => Service['nslcd'],
+        require => File[$nslcd_conf_dir]
+      }
+
       Class['pki'] ~> Service['nslcd']
     }
   }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name":    "simp-openldap",
-  "version": "4.1.3",
+  "version": "4.1.4",
   "author":  "simp",
   "summary": "Manages OpenLDAP and related security bindings",
   "license": "Apache-2.0",

--- a/spec/classes/pam_spec.rb
+++ b/spec/classes/pam_spec.rb
@@ -14,43 +14,74 @@ describe 'openldap::pam' do
           facts
         end
 
-        it { should compile.with_all_deps }
-        it { should create_class('auditd') }
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to create_class('auditd') }
         it {
-          should create_auditd__add_rules('ldap.conf').with({
+          is_expected.to create_auditd__add_rules('ldap.conf').with({
             :content => /CFG_etc_ldap/
           })
-          should create_auditd__add_rules('ldap.conf').that_requires('File[/etc/pam_ldap.conf]')
+          is_expected.to create_auditd__add_rules('ldap.conf').that_requires('File[/etc/pam_ldap.conf]')
         }
-        it { should create_class('pki').that_comes_before('File[/etc/pam_ldap.conf]') }
+        it { is_expected.to create_class('pki').that_comes_before('File[/etc/pam_ldap.conf]') }
         it {
           if (['RedHat', 'CentOS'].include?(facts[:operatingsystem])) && (facts[:operatingsystemrelease].to_s < '6.7')
-            should create_class('nscd')
+            is_expected.to create_class('nscd')
+            is_expected.to create_group('nslcd_group')
+            is_expected.to create_user('nslcd_user').that_requires('Group[nslcd_group]')
+            is_expected.to create_file('/etc/nslcd.d').that_requires('User[nslcd_user]')
+            is_expected.to create_file('/etc/nslcd.conf').with({
+              :content => /tls_cert\s+\/etc\/nslcd.d\/pki\/public\/#{facts[:fqdn]}.pub/,
+              :content => /tls_key\s+\/etc\/nslcd.d\/pki\/private\/#{facts[:fqdn]}.pem/,
+              :content => /tls_cacertdir\s+\/etc\/nslcd.d\/pki\/cacerts/,
+              :content => /tls_cacertfile\s+\/etc\/nslcd.d\/pki\/cacerts\/cacerts.pem/
+            })
+            is_expected.to create_service('nslcd').with({
+              :require => ['File[/etc/nslcd.conf]','File[/etc/nslcd.d]']
+            })
+            is_expected.to create_pki__copy('/etc/nslcd.d').that_requires('File[/etc/nslcd.d]')
           else
-            should create_class('sssd')
+            is_expected.to create_class('sssd')
           end
         }
         it {
-          should create_file('/etc/pam_ldap.conf').with({ :content => /ssl\s+start_tls/ })
-          should create_file('/etc/pam_ldap.conf').with({ :content => /binddn\s+.+/ })
-          should create_file('/etc/pam_ldap.conf').with({ :content => /bindpw\s+.+/ })
-          should create_file('/etc/pam_ldap.conf').with({ :content => /tls_checkpeer yes/ })
+          is_expected.to create_file('/etc/pam_ldap.conf').with({ :content => /ssl\s+start_tls/ })
+          is_expected.to create_file('/etc/pam_ldap.conf').with({ :content => /binddn\s+.+/ })
+          is_expected.to create_file('/etc/pam_ldap.conf').with({ :content => /bindpw\s+.+/ })
+          is_expected.to create_file('/etc/pam_ldap.conf').with({ :content => /tls_checkpeer yes/ })
         }
-        it { should contain_package("nss-pam-ldapd") }
-        it { should contain_package("openldap-clients.#{facts[:hardwaremodel]}") }
+        it { is_expected.to contain_package("nss-pam-ldapd") }
+        it { is_expected.to contain_package("openldap-clients.#{facts[:hardwaremodel]}") }
     
         context 'no_auditd' do
           let(:params){{ :use_auditd => false }}
     
-          it { should compile.with_all_deps }
-          it { should_not create_auditd__add_rules('ldap.conf') }
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to_not create_auditd__add_rules('ldap.conf') }
         end
     
-        context 'no_pki' do
-          let(:params){{ :ssl => false }}
+        context 'no_pki and use_simp_pki=false' do
+          let(:params){{
+            :ssl            => false,
+            :use_simp_pki   => false,
+            :tls_cacertfile => '/etc/nslcd.d/foopki/cacerts/cacerts.pem',
+            :tls_cacertdir  => '/etc/nslcd.d/foopki/cacerts',
+            :tls_key        => '/etc/nslcd.d/foopki/fookey.pem',
+            :tls_cert       => '/etc/nslcd.d/foopki/foocert.pub'
+          }}
     
-          it { should compile.with_all_deps }
-          it { should_not create_class('pki').that_comes_before('File[/etc/pam_ldap.conf]') }
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to_not create_class('pki').that_comes_before('File[/etc/pam_ldap.conf]') }
+          if (['RedHat', 'CentOS'].include?(facts[:operatingsystem])) && (facts[:operatingsystemrelease].to_s < '6.7')
+            it {
+              is_expected.to create_file('/etc/nslcd.conf').with({
+                :content => /tls_cert\s+\/etc\/nslcd.d\/foopki\/public\/foocert.pub/,
+                :content => /tls_key\s+\/etc\/nslcd.d\/foopki\/private\/fookey.pem/,
+                :content => /tls_cacertdir\s+\/etc\/nslcd.d\/foopki\/cacerts/,
+                :content => /tls_cacertfile\s+\/etc\/nslcd.d\/foopki\/cacerts\/cacerts.pem/
+              })
+            }
+          end
+          it { is_expected.to_not create_pki__copy('/etc/nslcd.d') }
         end
     
         context 'use_sssd' do
@@ -58,20 +89,20 @@ describe 'openldap::pam' do
             :use_sssd => true
           }}
     
-          it { should compile.with_all_deps }
-          it { should create_class('sssd') }
-          it { should compile.with_all_deps }
-          it { should create_file('/etc/pam_ldap.conf') }
-          it { should_not create_service('nscd').with_enable(true) }
-          it { should_not create_service('nslcd') }
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to create_class('sssd') }
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to create_file('/etc/pam_ldap.conf') }
+          it { is_expected.to_not create_service('nscd').with_enable(true) }
+          it { is_expected.to_not create_service('nslcd') }
         end
     
         context 'threads_is_default' do
           it {
             if (['RedHat', 'CentOS'].include?(facts[:operatingsystem])) && (facts[:operatingsystemrelease].to_s < '6.7')
-              should create_file('/etc/nslcd.conf').with({ :content => /threads 5/ })
+              is_expected.to create_file('/etc/nslcd.conf').with({ :content => /threads 5/ })
             else
-              should_not create_file('/etc/nslcd.conf')
+              is_expected.to_not create_file('/etc/nslcd.conf')
             end
           }
         end
@@ -83,10 +114,10 @@ describe 'openldap::pam' do
     
           it { 
             if (['RedHat', 'CentOS'].include?(facts[:operatingsystem])) && (facts[:operatingsystemrelease].to_s < '6.7')
-              should create_file('/etc/nslcd.conf').with({ :content => /threads 20/ })
-              should create_file('/etc/nslcd.conf').without({ :content => /threads 5/ })
+              is_expected.to create_file('/etc/nslcd.conf').with({ :content => /threads 20/ })
+              is_expected.to create_file('/etc/nslcd.conf').without({ :content => /threads 5/ })
             else
-              should_not create_file('/etc/nslcd.conf')
+              is_expected.to_not create_file('/etc/nslcd.conf')
             end
           }
         end

--- a/templates/etc/nslcd.conf.erb
+++ b/templates/etc/nslcd.conf.erb
@@ -32,7 +32,12 @@ ssl start_tls
 ssl <%= @ssl %>
 <% end -%>
 tls_reqcert <%= @tls_reqcert %>
-tls_cacertdir <%= @tls_cacertdir %>
+<% unless @_tls_cacertdir.empty? -%>
+tls_cacertdir <%= @_tls_cacertdir %>
+<% end -%>
+<% unless @_tls_cacertfile.empty? -%>
+tls_cacertfile <%= @_tls_cacertfile %>
+<% end -%>
 <% if @tls_randfile then -%>
 tls_randfile <%= @tls_randfile %>
 <% end -%>

--- a/templates/etc/pam_ldap.conf.erb
+++ b/templates/etc/pam_ldap.conf.erb
@@ -16,7 +16,7 @@ scope <%= @lscope %>
 deref <%= @deref %>
 timelimit <%= @timelimit %>
 <% if not @timeout.empty? -%>
-timeout = <%= @timeout %>
+timeout <%= @timeout %>
 <% end -%>
 bind_timelimit <%= @bind_timelimit %>
 <% if not @network_timeout.empty? -%>
@@ -69,12 +69,20 @@ ssl start_tls
 ssl on
 <%   end -%>
 tls_checkpeer <%= t_bool_xlat[@tls_checkpeer] %>
+<% unless @tls_cacertfile.empty? -%>
 tls_cacertfile <%= @tls_cacertfile %>
+<% end -%>
+<% unless @tls_cacertdir.empty? -%>
 tls_cacertdir <%= @tls_cacertdir %>
+<% end -%>
 tls_ciphers <%= Array(@tls_ciphers).join(':') %>
 <% if @use_certs then -%>
+<% unless @tls_cert.empty? -%>
 tls_cert <%= @tls_cert %>
+<% end -%>
+<% unless @tls_key.empty? -%>
 tls_key <%= @tls_key %>
+<% end -%>
 <% end -%>
 <% if @tls_randfile then -%>
 tls_randfile <%= @tls_randfile %>


### PR DESCRIPTION
- nslcd group and user are ensured.
- nslcd uid and gid default to 65 (nslcd). nslcd is no longer in the ldap group.
- Created an nslcd conf dir for convenient cert location.  Defaults to /etc/nslcd.d.
  If use_simp_pki is true, pki::copy copies the system certs here.
- nslcd.conf tls options now have proper defaults. Fixed syntax errors in nslcd.conf
  and pam_ldap.conf

SIMP-894 #comment Discovered during nfs acceptance testing
SIMP-904 #close configure nslcd in openldap
