### PR TITLE
(SIMP-1155) Acceptance tests for openldap

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -4,7 +4,6 @@ fixtures:
     auditd: "git://github.com/simp/pupmod-simp-auditd"
     augeasproviders_core: "git://github.com/simp/augeasproviders_core"
     augeasproviders_grub: "git://github.com/simp/augeasproviders_grub"
-    common: "git://github.com/simp/pupmod-simp-common"
     simplib: "git://github.com/simp/pupmod-simp-simplib"
     simpcat: "git://github.com/simp/pupmod-simp-concat"
     iptables: "git://github.com/simp/pupmod-simp-iptables"

--- a/.fixtures.yml.local
+++ b/.fixtures.yml.local
@@ -5,7 +5,6 @@ fixtures:
     auditd: "#{source_dir}/../auditd"
     augeasproviders_core: "#{source_dir}/../augeasproviders_core"
     augeasproviders_grub: "#{source_dir}/../augeasproviders_grub"
-    common: "#{source_dir}/../common"
     concat: "#{source_dir}/../concat"
     functions: "#{source_dir}/../functions"
     iptables: "#{source_dir}/../iptables"

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -21,6 +21,7 @@ class openldap::client (
     $sizelimit = '0',
     $timelimit = '15',
     $deref = 'never',
+    $use_tls = true,
     $tls_cacertdir = '/etc/pki/cacerts',
     $tls_cert = "/etc/pki/public/${::fqdn}.pub",
     $tls_key = "/etc/pki/private/${::fqdn}.pem",
@@ -44,7 +45,7 @@ class openldap::client (
     group   => 'root',
     mode    => '0600',
     replace => false,
-    content => "TLS_CACERTDIR ${tls_cacertdir}\nTLS_CERT ${tls_cert}\nTLS_KEY ${tls_key}\n"
+    content => template('openldap/ldaprc.erb')
   }
 
   validate_array_member($referrals,['on','off'])

--- a/manifests/server/conf/default_ldif.pp
+++ b/manifests/server/conf/default_ldif.pp
@@ -28,7 +28,6 @@ class openldap::server::conf::default_ldif (
   validate_integer($ppolicy_pwd_min_age)
   validate_integer($ppolicy_pwd_max_age)
   validate_integer($ppolicy_pwd_in_history)
-  validate_integer($ppolicy_pwd_in_history)
   validate_integer($ppolicy_pwd_check_quality)
   validate_integer($ppolicy_pwd_min_length)
   validate_integer($ppolicy_pwd_expire_warning)

--- a/manifests/slapo/ppolicy.pp
+++ b/manifests/slapo/ppolicy.pp
@@ -16,7 +16,7 @@
 #
 # [*min_points*]
 # Type: Integer
-# Default: '4'
+# Default: '3'
 #   The minimum number of character classes that must be included in your
 #   password for it to succeed.
 #
@@ -51,7 +51,7 @@
 #
 # [*max_consecutive_per_class*]
 # Type: Integer
-# Default: '0'
+# Default: '2'
 #   The maximum number of characters from any character class that can exist in
 #   a row.
 #
@@ -64,13 +64,13 @@ class openldap::slapo::ppolicy (
     $ppolicy_default='',
     $ppolicy_hash_cleartext='',
     $ppolicy_use_lockout='',
-    $min_points = '4',
+    $min_points = '3',
     $use_cracklib = true,
     $min_upper = '0',
     $min_lower = '0',
     $min_digit = '0',
     $min_punct = '0',
-    $max_consecutive_per_class = '0'
+    $max_consecutive_per_class = '2'
 ) {
   include '::openldap::server::dynamic_includes'
 

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -1,0 +1,126 @@
+require 'spec_helper_acceptance'
+require 'erb'
+
+test_name 'openldap class'
+
+describe 'openldap class' do
+  let(:server) { only_host_with_role(hosts, 'server') }
+  let(:slaves) { hosts_with_role(hosts, 'slave')}
+  let(:server_fqdn) { fact_on(server, 'fqdn') }
+  let(:domains) { fact_on(server, 'domain').split('.').map{ |d| "dc=#{d}" }.join(',') }
+
+  let(:server_hieradata) { File.read(File.expand_path('templates/server_hieradata.yaml.erb', File.dirname(__FILE__))) }
+  let(:server_hieradata_tls) { File.read(File.expand_path('templates/server_hieradata_tls.yaml.erb', File.dirname(__FILE__))) }
+  let(:add_testuser) { File.read(File.expand_path('templates/add_testuser.ldif.erb', File.dirname(__FILE__))) }
+  let(:add_testuser_to_admin) { File.read(File.expand_path('templates/add_testuser_to_admin.ldif.erb', File.dirname(__FILE__))) }
+
+  let(:server_manifest) {
+    <<-EOS
+      include 'openldap::server'
+    EOS
+  }
+
+
+  context 'default parameters (no pki)' do
+    it 'should configure server with tls disabled and with no errors' do
+      install_package(server, 'simp-ppolicy-check-password')
+      install_package(server, 'openldap-clients')
+      echo_on(server, domains)
+
+      on(server, 'mkdir -p /usr/local/sbin/simp')
+      set_hieradata_on(server, ERB.new(server_hieradata).result(binding))
+      apply_manifest_on(server, server_manifest, :catch_failures => true)
+      apply_manifest_on(server, server_manifest, :acceptable_exit_codes => [0,2])
+      apply_manifest_on(server, server_manifest, :acceptable_exit_codes => [0,2])
+
+      # reboot to apply auditd changes
+      # shell( 'shutdown -r now', { :expect_connection_failure => true } )
+    end
+    it 'should be idempotent' do
+      apply_manifest(server_manifest, {:catch_changes => true})
+    end
+
+
+    context 'user management' do
+      it 'should be able to connect and use ldapsearch' do
+        on(server, "ldapsearch -LLL -D cn=LDAPAdmin,ou=People,#{domains} -H ldap://#{server_fqdn} -w suP3rP@ssw0r!")
+      end
+
+      it 'should be able to add a user' do
+        create_remote_file(server, '/tmp/add_testuser.ldif', ERB.new(add_testuser).result(binding))
+
+        on(server, "ldapadd -D cn=LDAPAdmin,ou=People,#{domains} -H ldap://#{server_fqdn} -w suP3rP@ssw0r! -x -f /tmp/add_testuser.ldif")
+
+        result = on(server, "ldapsearch -LLL -D cn=LDAPAdmin,ou=People,#{domains} -H ldap://#{server_fqdn} -w suP3rP@ssw0r! -x uid=test.user")
+        expect(result.stdout).to include("dn: uid=test.user,ou=People,#{domains}")
+      end
+
+      it 'should be able to add user to group' do
+        create_remote_file(server, '/tmp/add_testuser_to_admin.ldif', ERB.new(add_testuser_to_admin).result(binding))
+
+        on(server, "ldapmodify -D cn=LDAPAdmin,ou=People,#{domains} -H ldap://#{server_fqdn} -w suP3rP@ssw0r! -x -f /tmp/add_testuser_to_admin.ldif")
+
+        result = on(server, "ldapsearch -LLL -D cn=LDAPAdmin,ou=People,#{domains} -H ldap://#{server_fqdn} -w suP3rP@ssw0r! -x cn=test.user")
+        expect(result.stdout).to include("dn: cn=test.user,ou=Group,#{domains}")
+      end
+
+      it 'should be able to expire user passwords using ppolicy' do
+       # set clock forward to expire test.user
+       on(server, "date --set='1 JAN 2020'; date")
+
+       # should error out with a password expired message
+       on(server, "ldapwhoami -D uid=test.user,ou=People,#{domains} -H ldap://#{server_fqdn} -x -w suP3rP@ssw0r! -e ppolicy", :acceptable_exit_codes => [49])
+
+       on(server, 'hwclock -w; date')
+      end
+
+      context 'should be able to check password complexity' do
+        password_list = [
+          'p@ssW0rd',      # too short
+          'SupErpAssW0rD', # not enough character classes
+          'SupRrpassW0rd', # too many character classes in a row
+        ]
+        password_list.each_with_index do |pass,i|
+          it "should reject bad password #{pass}" do
+            sleep(5)
+            result = on(server, "ldappasswd -D uid=test.user,ou=People,#{domains} -H ldap://#{server_fqdn} -w 'suP3rP@ssw0r!' -a 'suP3rP@ssw0r!' -s '#{pass}'", :acceptable_exit_codes => [1])
+            expect(result.stdout).to include("Result: Constraint violation (19)")
+          end
+        end
+
+        # this one should work
+        pass = '6q!Bqr3ek^K!9b'
+        it "should accept good password #{pass}" do
+          sleep(5)
+          on(server, "ldappasswd -D uid=test.user,ou=People,#{domains} -H ldap://#{server_fqdn} -w 'suP3rP@ssw0r!' -a 'suP3rP@ssw0r!' -s '#{pass}'")
+        end
+      end
+    end
+
+    context 'with tls enabled' do
+      it 'should be able to connect using tls and use ldapsearch' do
+        install_package(server, 'simp-ppolicy-check-password')
+        install_package(server, 'openldap-clients')
+        on(server, 'rm /root/.ldaprc', :accept_all_exit_codes => true)
+        on(server, 'mkdir -p /usr/local/sbin/simp', :accept_all_exit_codes => true)
+
+        # convert certs to pkcs12
+        certpath = '/etc/pki/simp-testing/pki'
+        on(server, "openssl pkcs12 -export -in #{certpath}/private/#{server_fqdn}.pem -out #{certpath}/private/#{server_fqdn}.p12 -passout pass: -name #{server_fqdn}")
+        on(server, "pk12util -i #{certpath}/private/#{server_fqdn}.p12 -d sql:/etc/openldap/certs -k /etc/openldap/certs/password -W '' -n #{server_fqdn}")
+        on(server, 'chown :ldap -R /etc/pki/simp-testing/')
+
+        set_hieradata_on(server, ERB.new(server_hieradata_tls).result(binding))
+        apply_manifest_on(server, server_manifest, :catch_failures => true)
+        apply_manifest_on(server, server_manifest, :acceptable_exit_codes => [0,2])
+
+        on(server, "ldapsearch -LLL -D cn=LDAPAdmin,ou=People,#{domains} -H ldap://#{server_fqdn} -Z -x -w suP3rP@ssw0r!")
+      end
+
+      it 'should reject non-tls connections' do
+        on(server, "ldapsearch -LLL -D cn=LDAPAdmin,ou=People,#{domains} -H ldap://#{server_fqdn} -x -w suP3rP@ssw0r!", :acceptable_exit_codes=> [13])
+      end
+    end
+
+  end
+end

--- a/spec/acceptance/files/add_testuser.ldif
+++ b/spec/acceptance/files/add_testuser.ldif
@@ -1,0 +1,29 @@
+dn: cn=test.user,ou=Group,#{domains}
+objectClass: posixGroup
+objectClass: top
+cn: test.user
+gidNumber: 10000
+description: 'Test user'
+dn: uid=test.user,ou=People,#{domains}
+uid: test.user
+cn: test.user
+givenName: Test
+sn: User
+mail: test.user@funurl.net
+objectClass: inetOrgPerson
+objectClass: posixAccount
+objectClass: top
+objectClass: shadowAccount
+objectClass: ldapPublicKey
+shadowMax: 180
+shadowMin: 1
+shadowWarning: 7
+shadowLastChange: 10701
+sshPublicKey:
+loginShell: /bin/bash
+uidNumber: 10000
+gidNumber: 10000
+homeDirectory: /home/test.user
+#suP3rP@ssw0r!
+userPassword: {SSHA}r2GaizHFWY8pcHpIClU0ye7vsO4uHv/y
+pwdReset: TRUE

--- a/spec/acceptance/files/add_testuser_to_admin.ldif
+++ b/spec/acceptance/files/add_testuser_to_admin.ldif
@@ -1,0 +1,4 @@
+dn: cn=administrators,ou=Group,#{domains}
+changetype: modify
+add: memberUid
+memberUid: test.user

--- a/spec/acceptance/nodesets/centos-66-x64.yml
+++ b/spec/acceptance/nodesets/centos-66-x64.yml
@@ -1,0 +1,32 @@
+HOSTS:
+  server:
+    roles:
+      - default
+      - server
+    yum_repos:
+      simp:
+        url: https://dl.bintray.com/simp/4.2.X
+        gpgkeys:
+          - https://raw.githubusercontent.com/NationalSecurityAgency/SIMP/master/GPGKEYS/RPM-GPG-KEY-SIMP
+    platform:   el-6-x86_64
+    box:        puppetlabs/centos-6.6-64-nocm
+    box_url:    https://vagrantcloud.com/puppetlabs/boxes/centos-6.6-64-nocm
+    hypervisor: vagrant
+  # slave1:
+  #   roles:
+  #     - slave
+  #   platform:   el-6-x86_64
+  #   box:        puppetlabs/centos-6.6-64-nocm
+  #   box_url:    https://vagrantcloud.com/puppetlabs/boxes/centos-6.6-64-nocm
+  #   hypervisor: vagrant
+  # slave2:
+  #   roles:
+  #     - slave
+  #   platform:   el-6-x86_64
+  #   box:        puppetlabs/centos-6.6-64-nocm
+  #   box_url:    https://vagrantcloud.com/puppetlabs/boxes/centos-6.6-64-nocm
+  #   hypervisor: vagrant
+CONFIG:
+  log_level:   verbose
+  type:        foss
+  vagrant_mem: 256

--- a/spec/acceptance/nodesets/centos-7-x64.yml
+++ b/spec/acceptance/nodesets/centos-7-x64.yml
@@ -1,0 +1,32 @@
+HOSTS:
+  server:
+    roles:
+      - default
+      - server
+    yum_repos:
+      simp:
+        url: https://dl.bintray.com/simp/5.1.X
+        gpgkeys:
+          - https://raw.githubusercontent.com/NationalSecurityAgency/SIMP/master/GPGKEYS/RPM-GPG-KEY-SIMP
+    platform:   el-7-x86_64
+    box:        puppetlabs/centos-7.0-64-nocm
+    box_url:    https://vagrantcloud.com/puppetlabs/boxes/centos-7.0-64-nocm
+    hypervisor: vagrant
+  # slave1:
+  #   roles:
+  #     - slave
+  #   platform:   el-7-x86_64
+  #   box:        puppetlabs/centos-7.0-64-nocm
+  #   box_url:    https://vagrantcloud.com/puppetlabs/boxes/centos-7.0-64-nocm
+  #   hypervisor: vagrant
+  # slave2:
+  #   roles:
+  #     - slave
+  #   platform:   el-7-x86_64
+  #   box:        puppetlabs/centos-7.0-64-nocm
+  #   box_url:    https://vagrantcloud.com/puppetlabs/boxes/centos-7.0-64-nocm
+  #   hypervisor: vagrant
+CONFIG:
+  log_level:       verbose
+  type:            foss
+  vagrant_mem: 256

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -1,0 +1,32 @@
+HOSTS:
+  server:
+    roles:
+      - default
+      - server
+    yum_repos:
+      simp:
+        url: https://dl.bintray.com/simp/5.1.X
+        gpgkeys:
+          - https://raw.githubusercontent.com/NationalSecurityAgency/SIMP/master/GPGKEYS/RPM-GPG-KEY-SIMP
+    platform:   el-7-x86_64
+    box:        puppetlabs/centos-7.0-64-nocm
+    box_url:    https://vagrantcloud.com/puppetlabs/boxes/centos-7.0-64-nocm
+    hypervisor: vagrant
+  # slave1:
+  #   roles:
+  #     - slave
+  #   platform:   el-7-x86_64
+  #   box:        puppetlabs/centos-7.0-64-nocm
+  #   box_url:    https://vagrantcloud.com/puppetlabs/boxes/centos-7.0-64-nocm
+  #   hypervisor: vagrant
+  # slave2:
+  #   roles:
+  #     - slave
+  #   platform:   el-7-x86_64
+  #   box:        puppetlabs/centos-7.0-64-nocm
+  #   box_url:    https://vagrantcloud.com/puppetlabs/boxes/centos-7.0-64-nocm
+  #   hypervisor: vagrant
+CONFIG:
+  log_level:       verbose
+  type:            foss
+  vagrant_mem: 256

--- a/spec/acceptance/templates/add_testuser.ldif.erb
+++ b/spec/acceptance/templates/add_testuser.ldif.erb
@@ -1,0 +1,29 @@
+dn: cn=test.user,ou=Group,<%= domains %>
+objectClass: posixGroup
+objectClass: top
+cn: test.user
+gidNumber: 10000
+description: 'Test user'
+
+dn: uid=test.user,ou=People,<%= domains %>
+uid: test.user
+cn: test.user
+givenName: Test
+sn: User
+mail: test.user@funurl.net
+objectClass: inetOrgPerson
+objectClass: posixAccount
+objectClass: top
+objectClass: shadowAccount
+objectClass: ldapPublicKey
+shadowMax: 1
+shadowMin: 1
+shadowWarning: 7
+shadowLastChange: 10701
+sshPublicKey:
+loginShell: /bin/bash
+uidNumber: 10000
+gidNumber: 10000
+homeDirectory: /home/test.user
+#suP3rP@ssw0r!
+userPassword: {SSHA}r2GaizHFWY8pcHpIClU0ye7vsO4uHv/y

--- a/spec/acceptance/templates/add_testuser_to_admin.ldif.erb
+++ b/spec/acceptance/templates/add_testuser_to_admin.ldif.erb
@@ -1,0 +1,4 @@
+dn: cn=administrators,ou=Group,<%= domains %>
+changetype: modify
+add: memberUid
+memberUid: test.user

--- a/spec/acceptance/templates/server_hieradata.yaml.erb
+++ b/spec/acceptance/templates/server_hieradata.yaml.erb
@@ -1,0 +1,31 @@
+---
+client_nets:
+ - 'ALL'
+use_simp_pki: false
+use_iptables: false
+use_nscd: false
+use_sssd: false
+enable_pki: false
+enable_logging: false
+
+openldap::server::conf::default_ldif::ppolicy_pwd_min_age: 0
+openldap::server::conf::default_ldif::ppolicy_pwd_failure_count_interval: 4
+
+ldap::uri:
+ - 'ldap://<%= server_fqdn %>'
+ldap::base_dn: '<%= domains %>'
+ldap::bind_dn: 'cn=hostAuth,ou=Hosts,<%= domains %>'
+ldap::bind_pw: 'foobarbaz'
+ldap::bind_hash: '{SSHA}BNPDR0qqE6HyLTSlg13T0e/+yZnSgYQz'
+ldap::sync_dn: 'cn=LDAPSync,ou=Hosts,<%= domains %>'
+ldap::sync_pw: 'foobarbaz'
+ldap::sync_hash: '{SSHA}BNPDR0qqE6HyLTSlg13T0e/+yZnSgYQz'
+ldap::root_dn: 'cn=LDAPAdmin,ou=People,<%= domains %>'
+ldap::root_hash: '{SSHA}BNPDR0qqE6HyLTSlg13T0e/+yZnSgYQz'
+ldap::master: 'ldap://<%= server_fqdn %>'
+# suP3rP@ssw0r!
+ldap::root_hash: "{SSHA}ZcqPNbcqQhDNF5jYTLGl+KAGcrHNW9oo"
+
+openldap::server::use_tcpwrappers: false
+openldap::server::conf::use_tls: false
+openldap::client::use_tls: false

--- a/spec/acceptance/templates/server_hieradata_tls.yaml.erb
+++ b/spec/acceptance/templates/server_hieradata_tls.yaml.erb
@@ -1,0 +1,41 @@
+---
+client_nets:
+ - 'ALL'
+use_simp_pki: false
+use_iptables: false
+use_nscd: false
+use_sssd: false
+enable_pki: false
+enable_logging: false
+
+openldap::server::conf::default_ldif::ppolicy_pwd_min_age: 0
+openldap::server::conf::default_ldif::ppolicy_pwd_failure_count_interval: 4
+
+ldap::uri:
+ - 'ldap://<%= server_fqdn %>'
+ldap::base_dn: '<%= domains %>'
+ldap::bind_dn: 'cn=hostAuth,ou=Hosts,<%= domains %>'
+ldap::bind_pw: 'foobarbaz'
+ldap::bind_hash: '{SSHA}BNPDR0qqE6HyLTSlg13T0e/+yZnSgYQz'
+ldap::sync_dn: 'cn=LDAPSync,ou=Hosts,<%= domains %>'
+ldap::sync_pw: 'foobarbaz'
+ldap::sync_hash: '{SSHA}BNPDR0qqE6HyLTSlg13T0e/+yZnSgYQz'
+ldap::root_dn: 'cn=LDAPAdmin,ou=People,<%= domains %>'
+ldap::root_hash: '{SSHA}BNPDR0qqE6HyLTSlg13T0e/+yZnSgYQz'
+ldap::master: 'ldap://<%= server_fqdn %>'
+# suP3rP@ssw0r!
+ldap::root_hash: "{SSHA}ZcqPNbcqQhDNF5jYTLGl+KAGcrHNW9oo"
+
+openldap::server::use_tcpwrappers: false
+openldap::server::conf::use_tls: true
+openldap::client::use_tls: true
+
+# Need to tell our modules where our certs live!
+# This is a good test of the case where users don't want to use our PKI module.
+pki_dir : '/etc/pki/simp-testing/pki'
+openldap::client::tls_cacertdir : "%{hiera('pki_dir')}/cacerts"
+openldap::client::tls_cert : "%{hiera('pki_dir')}/public/<%= server_fqdn %>.pub"
+openldap::client::tls_key: "%{hiera('pki_dir')}/private/<%= server_fqdn %>.pem"
+openldap::server::conf::tlsCACertificatePath: "%{hiera('pki_dir')}/cacerts"
+openldap::server::conf::tlsCertificateFile: "%{hiera('pki_dir')}/public/<%= server_fqdn %>.pub"
+openldap::server::conf::tlsCertificateKeyFile:  "%{hiera('pki_dir')}/private/<%= server_fqdn %>.pem"

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,0 +1,55 @@
+require 'beaker-rspec'
+require 'tmpdir'
+require 'yaml'
+require 'simp/beaker_helpers'
+include Simp::BeakerHelpers
+
+unless ENV['BEAKER_provision'] == 'no'
+  hosts.each do |host|
+    # Install Puppet
+    if host.is_pe?
+      install_pe
+    else
+      install_puppet
+    end
+  end
+end
+
+# returns an Array of puppet modules declared in .fixtures.yml
+def pupmods_in_fixtures_yaml
+  require 'yaml'
+  fixtures_yml = File.expand_path( '../.fixtures.yml', File.dirname(__FILE__))
+  data         = YAML.load_file( fixtures_yml )
+  repos        = data.fetch('fixtures').fetch('repositories').keys
+  symlinks     = data.fetch('fixtures').fetch('symlinks', {}).keys
+  (repos + symlinks)
+end
+
+
+RSpec.configure do |c|
+  # ensure that environment OS is ready on each host
+  fix_errata_on hosts
+
+  # Readable test descriptions
+  c.formatter = :documentation
+
+  # Configure all nodes in nodeset
+  c.before :suite do
+    begin
+      # Install modules and dependencies from spec/fixtures/modules
+      copy_fixture_modules_to( hosts )
+
+      # Generate and install PKI certificates on each SUT
+      Dir.mktmpdir do |cert_dir|
+        run_fake_pki_ca_on( default, hosts, cert_dir )
+        hosts.each{ |sut| copy_pki_to( sut, cert_dir, '/etc/pki/simp-testing' )}
+      end
+    rescue StandardError, ScriptError => e
+      if ENV['PRY']
+        require 'pry'; binding.pry
+      else
+        raise e
+      end
+    end
+  end
+end

--- a/templates/etc/openldap/default.ldif.erb
+++ b/templates/etc/openldap/default.ldif.erb
@@ -107,12 +107,11 @@ pwdAttribute: userPassword
 pwdMinAge: <%= @ppolicy_pwd_min_age %>
 pwdMaxAge: <%= @ppolicy_pwd_max_age %>
 pwdInHistory: <%= @ppolicy_pwd_in_history %>
-<% 
+<%
     if scope.function_defined(['$_simp_ppolicy_check_password']) &&
       @_simp_ppolicy_check_password &&
       !"#{@_simp_ppolicy_check_password}".empty?
 -%>
-
 pwdCheckQuality: <%= @ppolicy_pwd_check_quality %>
 <% else -%>
 pwdCheckQuality: 0
@@ -127,7 +126,7 @@ pwdFailureCountInterval: <%= @ppolicy_pwd_failure_count_interval %>
 pwdMustChange: <%= @ppolicy_pwd_must_change.to_s.upcase %>
 pwdAllowUserChange: <%= @ppolicy_pwd_allow_user_change.to_s.upcase %>
 pwdSafeModify: <%= @ppolicy_pwd_safe_modify.to_s.upcase %>
-<% 
+<%
     if scope.function_defined(['$_simp_ppolicy_check_password']) &&
       @_simp_ppolicy_check_password &&
       !"#{@_simp_ppolicy_check_password}".empty?
@@ -157,7 +156,7 @@ pwdFailureCountInterval: 900
 pwdMustChange: FALSE
 pwdAllowUserChange: FALSE
 pwdSafeModify: FALSE
-<% 
+<%
     if scope.function_defined(['$_simp_ppolicy_check_password']) &&
       @_simp_ppolicy_check_password &&
       !"#{@_simp_ppolicy_check_password}".empty?

--- a/templates/etc/openldap/ldap.conf.erb
+++ b/templates/etc/openldap/ldap.conf.erb
@@ -5,10 +5,12 @@ REFERRALS           <%= @referrals %>
 SIZELIMIT           <%= @sizelimit %>
 TIMELIMIT           <%= @timelimit %>
 DEREF               <%= @dref %>
+<% if @use_tls -%>
 TLS_CACERTDIR       <%= @tls_cacertdir %>
 TLS_CIPHER_SUITE    <%= Array(@tls_cipher_suite).join(':') %>
 TLS_REQCERT         <%= @tls_reqcert %>
 TLS_CRLCHECK        <%= @tls_crlcheck %>
-<% if not @tls_crlfile.empty? -%>
+<%   if not @tls_crlfile.empty? -%>
 TLS_CRLFILE         <%= @tls_crlfile %>
+<%   end -%>
 <% end -%>

--- a/templates/etc/openldap/slapd.conf.erb
+++ b/templates/etc/openldap/slapd.conf.erb
@@ -139,10 +139,10 @@ TLSCRLFile <%= @tlsCRLFile %>
 <%   if not @tlsCACertificatePath.empty? then -%>
 TLSCACertificatePath <%= @tlsCACertificatePath %>
 <%   end -%>
-<% end -%>
 
 security <%= @security %>
 password-hash {<%= @password_hash %>}
+<% end -%>
 
 <% if not @bind_anon then -%>
 disallow bind_anon

--- a/templates/ldaprc.erb
+++ b/templates/ldaprc.erb
@@ -1,0 +1,5 @@
+<% if @use_tls -%>
+TLS_CACERTDIR <%= @tls_cacertdir %>
+TLS_CERT <%= @tls_cert %>
+TLS_KEY <%= @tls_key %>
+<% end -%>


### PR DESCRIPTION
Acceptance tests were written to cover the following situations:
- applying the module
- applying the module idempotently
- add user
- add user to admin group
- expiring users with ppolicy
- checking password complexity
- enabling tls
- rejecting non-tls connections with tls enabled

These tests do not test nscd or sssd, just openldap. They also don't use
any SIMP features.

(SIMP-1179) Update client.pp to disable tls

Created a template the .ldaprc file resource and put all logic for tls inside
it, leaving an empty file if tls is disabled. openldap::client::use_tls
can be used to disable tls on the client. Edited the ldap.conf.erb template to
not include tls-related entries if disabled. Changed a few of the
default values in default_ldif.pp to closer reflect password standards
set by the pam module.

SIMP-1155 #close
SIMP-1179 #close
