### PR TITLE
(SIMP-1190) Idempotency fix fo Exec[bootstrap_ldap]

### DIFF
--- a/manifests/server/service.pp
+++ b/manifests/server/service.pp
@@ -21,6 +21,7 @@ class openldap::server::service (
         /usr/sbin/slapadd -l /etc/openldap/default.ldif -f /etc/openldap/slapd.conf; \
         /bin/chown -h -R ldap.ldap /var/lib/ldap/*; \
         /bin/touch /etc/openldap/puppet_bootstrapped.lock; \
+        /bin/chown root:ldap /etc/openldap/puppet_bootstrapped.lock; \
         /bin/echo 'Bootstrapped LDAP';",
     onlyif    => '/usr/local/sbin/ldap_bootstrap_check.sh',
     logoutput => true,


### PR DESCRIPTION
This explicitly sets the ownership on the bootstrap lockfile created by
`Exec[bootstrap_ldap]` via its command in order to remain idempotent.
Previously the file was created as the user executing Puppet (usually
`root:root`) which conflicted with the recursively-managed directory in
which it is contained.  Because the directory was created first, the
`File` did adjust the group ownership of the lock file, but instead
would correct it on a subsiquent run-- a non-idempotent action.
