### PR TITLE
(SIMP-1241) Remove ensure of ruby-ldap

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Wed Jul 13 2016 Nick Markowski <nmarkowski@keywcorp.com> - 4.1.7-0
+- Ruby-ldap is not needed in this module, and is therefore no longer ensured
+  present.
+
 * Thu Jul 07 2016 Nick Miller <nick.miller@onyxpoint.com> - 4.1.6-0
 - Added acceptance tests
 - Added a parameter to the client class to disable tls connections. This makes

--- a/manifests/pam.pp
+++ b/manifests/pam.pp
@@ -371,6 +371,5 @@ class openldap::pam (
 
   package { "openldap-clients.${::hardwaremodel}": ensure => 'latest' }
   package { 'nss-pam-ldapd':                       ensure => 'latest' }
-  package { 'ruby-ldap':                           ensure => 'latest' }
 
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name":    "simp-openldap",
-  "version": "4.1.6",
+  "version": "4.1.7",
   "author":  "simp",
   "summary": "Manages OpenLDAP and related security bindings",
   "license": "Apache-2.0",


### PR DESCRIPTION
Ruby-ldap is not needed in this module.

SIMP-1241 #close
SIMP-1240 #comment remove ruby-ldap from openldap