### PR TITLE
(SIMP-1450) Update to use new 'simpcat'

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Fri Sep 30 2016 Trevor Vaughan <tvaughan@onyxpoint.com> - 5.0.0-0
+- Updated to use the version of 'simpcat' that does not conflict with
+  'puppetlabs/concat'.
+
 * Mon Aug 01 2016 Nicholas Hughes <nicholasmhughes@gmail.com> - 4.1.8-0
 - Corrected variable references in pam_ldap.conf.erb
 

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -164,7 +164,7 @@ class openldap::server (
       group     => 'ldap',
       mode      => '0640',
       require   => Package["openldap-servers.${::hardwaremodel}"],
-      subscribe => Concat_build['slapd_dynamic_includes'],
+      subscribe => Simpcat_build['slapd_dynamic_includes'],
       notify    => Class['openldap::server::service'],
       audit     => content
   }

--- a/manifests/server/access.pp
+++ b/manifests/server/access.pp
@@ -13,9 +13,9 @@
 class openldap::server::access {
   include '::openldap::server'
 
-  $fragdir = fragmentdir('slapd_access')
+  $fragdir = simpcat_fragmentdir('slapd_access')
 
-  concat_build { 'slapd_access':
+  simpcat_build { 'slapd_access':
     order  => '*.inc',
     target => "${fragdir}_slapd.access",
     notify => Exec['postprocess_slapd.access']

--- a/manifests/server/access/add.pp
+++ b/manifests/server/access/add.pp
@@ -40,7 +40,7 @@ define openldap::server::access::add (
 {
   $l_name = regsubst($name,'/','_')
 
-  concat_fragment { "slapd_access+${order}_${l_name}.inc":
+  simpcat_fragment { "slapd_access+${order}_${l_name}.inc":
     content => template('openldap/slapd.access.add.erb')
   }
 

--- a/manifests/server/dynamic_includes.pp
+++ b/manifests/server/dynamic_includes.pp
@@ -7,7 +7,7 @@
 class openldap::server::dynamic_includes {
   include '::openldap::server'
 
-  concat_build { 'slapd_dynamic_includes':
+  simpcat_build { 'slapd_dynamic_includes':
     order  => '*.inc',
     target => '/etc/openldap/dynamic_includes',
     before => Exec['bootstrap_ldap']

--- a/manifests/server/dynamic_includes/add.pp
+++ b/manifests/server/dynamic_includes/add.pp
@@ -25,7 +25,7 @@ define openldap::server::dynamic_includes::add (
 {
   $l_name = regsubst($name,'/','_')
 
-  concat_fragment { "slapd_dynamic_includes+${order}_${l_name}.inc":
+  simpcat_fragment { "slapd_dynamic_includes+${order}_${l_name}.inc":
     content => $content
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name":    "simp-openldap",
-  "version": "4.1.8",
+  "version": "5.0.8",
   "author":  "simp",
   "summary": "Manages OpenLDAP and related security bindings",
   "license": "Apache-2.0",
@@ -35,7 +35,7 @@
     },
     {
       "name": "simp/simpcat",
-      "version_requirement": ">= 2.0.0"
+      "version_requirement": ">= 6.0.0"
     },
     {
       "name": "simp/simplib",

--- a/spec/classes/server/access_spec.rb
+++ b/spec/classes/server/access_spec.rb
@@ -11,7 +11,7 @@ describe 'openldap::server::access' do
         it { is_expected.to create_class('openldap::server') }
 
         it { is_expected.to compile.with_all_deps }
-        it { is_expected.to create_concat_build('slapd_access').that_notifies('Exec[postprocess_slapd.access]') }
+        it { is_expected.to create_simpcat_build('slapd_access').that_notifies('Exec[postprocess_slapd.access]') }
         it { is_expected.to create_exec('postprocess_slapd.access').that_requires('File[/usr/local/sbin/simp/build_slapd_access.rb]') }
         it { is_expected.to create_file('/usr/local/sbin/simp/build_slapd_access.rb') }
         it {

--- a/spec/classes/server/dynamic_includes_spec.rb
+++ b/spec/classes/server/dynamic_includes_spec.rb
@@ -8,7 +8,7 @@ describe 'openldap::server::dynamic_includes' do
           facts
         end
 
-        it { is_expected.to create_concat_build('slapd_dynamic_includes').with({
+        it { is_expected.to create_simpcat_build('slapd_dynamic_includes').with({
             :target => '/etc/openldap/dynamic_includes',
             :before => 'Exec[bootstrap_ldap]'
           })

--- a/spec/classes/server_spec.rb
+++ b/spec/classes/server_spec.rb
@@ -44,7 +44,7 @@ describe 'openldap::server' do
 
         it { is_expected.to create_file('/etc/openldap/dynamic_includes').with({
             :require    => "Package[openldap-servers.#{facts[:hardwaremodel]}]",
-            :subscribe  => 'Concat_build[slapd_dynamic_includes]'
+            :subscribe  => 'Simpcat_build[slapd_dynamic_includes]'
           })
         }
 

--- a/spec/defines/server/access/add_spec.rb
+++ b/spec/defines/server/access/add_spec.rb
@@ -19,10 +19,10 @@ describe 'openldap::server::access::add' do
         it { should compile.with_all_deps }
 
         it {
-          should create_concat_fragment("slapd_access+#{params[:order]}_#{title}.inc").with_content(
+          should create_simpcat_fragment("slapd_access+#{params[:order]}_#{title}.inc").with_content(
             /Who: #{params[:who]}/
           )
-          should create_concat_fragment("slapd_access+#{params[:order]}_#{title}.inc").with_content(
+          should create_simpcat_fragment("slapd_access+#{params[:order]}_#{title}.inc").with_content(
             /What: #{params[:what]}/
           )
         }

--- a/spec/defines/server/dynamic_includes/add_spec.rb
+++ b/spec/defines/server/dynamic_includes/add_spec.rb
@@ -17,7 +17,7 @@ describe 'openldap::server::dynamic_includes::add' do
 
         it { should compile.with_all_deps }
 
-        it { should create_concat_fragment("slapd_dynamic_includes+#{params[:order]}_#{title}.inc").with_content(/#{params[:content]}/) }
+        it { should create_simpcat_fragment("slapd_dynamic_includes+#{params[:order]}_#{title}.inc").with_content(/#{params[:content]}/) }
       end
     end
   end

--- a/templates/etc/openldap/default.ldif.erb
+++ b/templates/etc/openldap/default.ldif.erb
@@ -108,7 +108,7 @@ pwdMinAge: <%= @ppolicy_pwd_min_age %>
 pwdMaxAge: <%= @ppolicy_pwd_max_age %>
 pwdInHistory: <%= @ppolicy_pwd_in_history %>
 <%
-    if scope.function_defined(['$_simp_ppolicy_check_password']) &&
+    if has_variable?('_simp_ppolicy_check_password') &&
       @_simp_ppolicy_check_password &&
       !"#{@_simp_ppolicy_check_password}".empty?
 -%>
@@ -127,7 +127,7 @@ pwdMustChange: <%= @ppolicy_pwd_must_change.to_s.upcase %>
 pwdAllowUserChange: <%= @ppolicy_pwd_allow_user_change.to_s.upcase %>
 pwdSafeModify: <%= @ppolicy_pwd_safe_modify.to_s.upcase %>
 <%
-    if scope.function_defined(['$_simp_ppolicy_check_password']) &&
+    if has_variable?('_simp_ppolicy_check_password') &&
       @_simp_ppolicy_check_password &&
       !"#{@_simp_ppolicy_check_password}".empty?
 -%>
@@ -157,7 +157,7 @@ pwdMustChange: FALSE
 pwdAllowUserChange: FALSE
 pwdSafeModify: FALSE
 <%
-    if scope.function_defined(['$_simp_ppolicy_check_password']) &&
+    if has_variable?('_simp_ppolicy_check_password') &&
       @_simp_ppolicy_check_password &&
       !"#{@_simp_ppolicy_check_password}".empty?
 -%>


### PR DESCRIPTION
Updated to use the version of 'simpcat' that does not conflict with
'puppetlabs/concat'.

SIMP-1450 #comment Update to use deconflicted 'simpcat'
SIMP-843 #comment Deconflicted 'openldap'
