### PR TITLE
(SIMP-1595) Provide complete dependency boundaries

### DIFF
--- a/build/rpm_metadata/requires
+++ b/build/rpm_metadata/requires
@@ -1,13 +1,25 @@
-# Drop all Requires, Obsoletes, and Provides statements in here
 
-Requires: pupmod-simp-auditd >= 4.1.0-2
-Requires: pupmod-simp-compliance_markup
-Requires: pupmod-simp-iptables >= 4.1.0-3
-Requires: pupmod-simp-logrotate >= 4.1.0-0
-Requires: pupmod-simp-nscd >= 5.0.0-7
-Requires: pupmod-simp-pki >= 3.0.0-0
-Requires: pupmod-simp-rsyslog >= 5.0.0-0
-Requires: pupmod-simp-simpcat >= 2.0.0-0
-Requires: pupmod-simp-sssd >= 4.0.0-1
-Requires: pupmod-simp-tcpwrappers >= 2.1.0-0
+# Drop all Requires, Obsoletes, and Provides statements in here
 Obsoletes: pupmod-openldap-test >= 0.0.1
+Requires: pupmod-simp-auditd < 6.0.0-0
+Requires: pupmod-simp-auditd >= 5.1.0-0
+Requires: pupmod-simp-compliance_markup < 2.0.0-0
+Requires: pupmod-simp-compliance_markup >= 1.0.1-0
+Requires: pupmod-simp-iptables < 5.0.0-0
+Requires: pupmod-simp-iptables >= 4.1.4-0
+Requires: pupmod-simp-logrotate < 5.0.0-0
+Requires: pupmod-simp-logrotate >= 4.1.0-0
+Requires: pupmod-simp-nscd < 6.0.0-0
+Requires: pupmod-simp-nscd >= 5.0.1-0
+Requires: pupmod-simp-pki < 5.0.0-0
+Requires: pupmod-simp-pki >= 4.2.4-0
+Requires: pupmod-simp-rsyslog < 6.0.0-0
+Requires: pupmod-simp-rsyslog >= 5.1.0-0
+Requires: pupmod-simp-simpcat < 6.0.0-0
+Requires: pupmod-simp-simpcat >= 5.0.1-0
+Requires: pupmod-simp-simplib < 2.0.0-0
+Requires: pupmod-simp-simplib >= 1.3.1-0
+Requires: pupmod-simp-sssd < 5.0.0-0
+Requires: pupmod-simp-sssd >= 4.1.3-0
+Requires: pupmod-simp-tcpwrappers < 5.0.0-0
+Requires: pupmod-simp-tcpwrappers >= 4.1.0-0

--- a/metadata.json
+++ b/metadata.json
@@ -1,57 +1,62 @@
 {
-  "name":    "simp-openldap",
+  "name": "simp-openldap",
   "version": "4.1.9",
-  "author":  "simp",
+  "author": "simp",
   "summary": "Manages OpenLDAP and related security bindings",
   "license": "Apache-2.0",
-  "source":  "https://github.com/simp/pupmod-simp-openldap",
+  "source": "https://github.com/simp/pupmod-simp-openldap",
   "project_page": "https://github.com/simp/pupmod-simp-openldap",
-  "issues_url":   "https://simp-project.atlassian.net",
-  "tags": [ "simp", "openldap", "pki", "tls" ],
+  "issues_url": "https://simp-project.atlassian.net",
+  "tags": [
+    "simp",
+    "openldap",
+    "pki",
+    "tls"
+  ],
   "dependencies": [
     {
       "name": "simp/auditd",
-      "version_requirement": ">= 4.1.0"
+      "version_requirement": ">= 5.1.0 < 6.0.0"
     },
     {
       "name": "simp/iptables",
-      "version_requirement": ">= 4.1.0"
+      "version_requirement": ">= 4.1.4 < 5.0.0"
     },
     {
       "name": "simp/logrotate",
-      "version_requirement": ">= 4.1.0"
+      "version_requirement": ">= 4.1.0 < 5.0.0"
     },
     {
       "name": "simp/nscd",
-      "version_requirement": ">= 5.0.0"
+      "version_requirement": ">= 5.0.1 < 6.0.0"
     },
     {
       "name": "simp/pki",
-      "version_requirement": ">= 3.0.0"
+      "version_requirement": ">= 4.2.4 < 5.0.0"
     },
     {
       "name": "simp/rsyslog",
-      "version_requirement": ">= 5.0.0"
+      "version_requirement": ">= 5.1.0 < 6.0.0"
     },
     {
       "name": "simp/simpcat",
-      "version_requirement": ">= 2.0.0"
+      "version_requirement": ">= 5.0.1 < 6.0.0"
     },
     {
       "name": "simp/simplib",
-      "version_requirement": ">= 1.0.1"
+      "version_requirement": ">= 1.3.1 < 2.0.0"
     },
     {
       "name": "simp/sssd",
-      "version_requirement": ">= 4.0.0"
+      "version_requirement": ">= 4.1.3 < 5.0.0"
     },
     {
       "name": "simp/tcpwrappers",
-      "version_requirement": ">= 2.1.0"
+      "version_requirement": ">= 4.1.0 < 5.0.0"
     },
     {
       "name": "simp/compliance_markup",
-      "version_requirement": ">= 1.0.0"
+      "version_requirement": ">= 1.0.1 < 2.0.0"
     }
   ],
   "operatingsystem_support": [
@@ -71,4 +76,3 @@
     }
   ]
 }
-


### PR DESCRIPTION
Before this patch, dependencies in `metadata.json` and
`build/rpm_metadata/requires` were missing upper boundaries and often
listed inaccurate lower boundaries.  This created an extremely fragile
5.2.X/4.3.X module ecosystem on the Forge, as a major release in any
dependency would be certain to break the module.

This commit resolves the issue by introducing upper and lower boundaries
for each dependency in `metadata.json` and propagates those dependencies
to the RPM dependencies listed in `build/rpm_metadata/requires`.

The minimum version boundaries were determined from the modules as they
were checked out in `simp-core` for the latest SIMP 5.2.X/4.3.X release
(with the addition recent z-version bumps from Forge-readiness patches).

SIMP-1595 #comment Fixed `pupmod-simp-openldap`
SIMP-1654 #close