### PR TITLE
(SIMP-1571) Use hiera multiple ldap URIs

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+* Thu Oct 06 2016 Liz Nemsick <lnemsick.simp@gmail.com> - 4.1.9-0
+- Fixed bug in which multiple URIs in ldap hieradata were not written
+  into ldap.conf.
+- Corrected variable reference in ldap.conf.erb
+
 * Mon Aug 01 2016 Nicholas Hughes <nicholasmhughes@gmail.com> - 4.1.8-0
 - Corrected variable references in pam_ldap.conf.erb
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name":    "simp-openldap",
-  "version": "4.1.8",
+  "version": "4.1.9",
   "author":  "simp",
   "summary": "Manages OpenLDAP and related security bindings",
   "license": "Apache-2.0",

--- a/spec/classes/client_spec.rb
+++ b/spec/classes/client_spec.rb
@@ -1,19 +1,87 @@
 require 'spec_helper'
 
+ldap_conf_content = {
+  :default =>
+    "URI                 ldap://server1.bar.baz ldap://server2.bar.baz\n" +
+    "BASE                ou=foo,dc=bar,dc=baz\n" +
+    "BINDDN              cn=hostAuth,ou=Hosts,ou=foo,dc=bar,dc=baz\n" +
+    "REFERRALS           on\n" +
+    "SIZELIMIT           0\n" +
+    "TIMELIMIT           15\n" +
+    "DEREF               never\n" +
+    "TLS_CACERTDIR       /etc/pki/cacerts\n" +
+    "TLS_CIPHER_SUITE    HIGH:-SSLv2\n" +
+    "TLS_REQCERT         allow\n" +
+    "TLS_CRLCHECK        none\n",
+
+  :with_crlfile =>
+    "URI                 ldap://server1.bar.baz ldap://server2.bar.baz\n" +
+    "BASE                ou=foo,dc=bar,dc=baz\n" +
+    "BINDDN              cn=hostAuth,ou=Hosts,ou=foo,dc=bar,dc=baz\n" +
+    "REFERRALS           on\n" +
+    "SIZELIMIT           0\n" +
+    "TIMELIMIT           15\n" +
+    "DEREF               never\n" +
+    "TLS_CACERTDIR       /etc/pki/cacerts\n" +
+    "TLS_CIPHER_SUITE    HIGH:-SSLv2\n" +
+    "TLS_REQCERT         allow\n" +
+    "TLS_CRLCHECK        none\n" +
+    "TLS_CRLFILE         /some/path/my_crlfile\n",
+
+  :without_tls =>
+    "URI                 ldap://server1.bar.baz ldap://server2.bar.baz\n" +
+    "BASE                ou=foo,dc=bar,dc=baz\n" +
+    "BINDDN              cn=hostAuth,ou=Hosts,ou=foo,dc=bar,dc=baz\n" +
+    "REFERRALS           on\n" +
+    "SIZELIMIT           0\n" +
+    "TIMELIMIT           15\n" +
+    "DEREF               never\n"
+}
+
+ldaprc_content = {
+  :default =>
+    "TLS_CACERTDIR /etc/pki/cacerts\n" +
+    "TLS_CERT /etc/pki/public/myserver.test.local.pub\n" +
+    "TLS_KEY /etc/pki/private/myserver.test.local.pem\n",
+
+  :with_crlfile =>
+    "TLS_CACERTDIR /etc/pki/cacerts\n" +
+    "TLS_CERT /etc/pki/public/myserver.test.local.pub\n" +
+    "TLS_KEY /etc/pki/private/myserver.test.local.pem\n",
+
+  :without_tls => ""
+}
+
+shared_examples_for "a ldap config generator" do
+  it { is_expected.to compile.with_all_deps }
+  it { is_expected.to create_class('openldap') }
+  it { is_expected.to create_class('openldap::client') }
+  it { is_expected.to create_file('/etc/openldap/ldap.conf').with_content( ldap_conf_content[content_option] ) }
+  it { is_expected.to create_file('/root/.ldaprc').with_content( ldaprc_content[content_option] ) }
+end
+
 describe 'openldap::client' do
   context 'supported operating systems' do
     on_supported_os.each do |os, facts|
       context "on #{os}" do
-        let(:facts) do
-          facts
+        let(:facts) { facts.merge({ :fqdn => 'myserver.test.local' }) }
+
+        context 'Generates files with TLS but without CRL file by default' do
+          let(:content_option) { :default }
+          it_should_behave_like "a ldap config generator"
         end
 
-        it { is_expected.to create_class('openldap') }
-        it { is_expected.to create_class('openldap::client') }
+        context 'Generates files with TLS and specified CRL file' do
+          let(:content_option) { :with_crlfile }
+          let(:params) { { :tls_crlfile => '/some/path/my_crlfile' } }
+          it_should_behave_like "a ldap config generator"
+        end
 
-        it { is_expected.to compile.with_all_deps }
-        it { is_expected.to create_file('/etc/openldap/ldap.conf').with_content(/TLS_CIPHER_SUITE\s+HIGH:-SSLv2/) }
-        it { is_expected.to create_file('/root/.ldaprc') }
+        context 'Generates files without TLS' do
+          let(:content_option) { :without_tls }
+          let(:params) { { :use_tls => false } }
+          it_should_behave_like "a ldap config generator"
+        end
       end
     end
   end

--- a/templates/etc/openldap/ldap.conf.erb
+++ b/templates/etc/openldap/ldap.conf.erb
@@ -1,10 +1,10 @@
-URI                 <%= Array(@uri).flatten.last %>
+URI                 <%= Array(@uri).join(' ') %>
 BASE                <%= @base %>
 BINDDN              <%= @bind_dn %>
 REFERRALS           <%= @referrals %>
 SIZELIMIT           <%= @sizelimit %>
 TIMELIMIT           <%= @timelimit %>
-DEREF               <%= @dref %>
+DEREF               <%= @deref %>
 <% if @use_tls -%>
 TLS_CACERTDIR       <%= @tls_cacertdir %>
 TLS_CIPHER_SUITE    <%= Array(@tls_cipher_suite).join(':') %>


### PR DESCRIPTION
- Fixed bug in which multiple URIs in ldap hiera were not written into
  ldap.conf.
- Fixed bug whereby DEREF configuration value in ldap.conf was not
  populated correctly.

SIMP-1571 #close