### PR TITLE
(SIMP-2118) Reset max_consecutive_per_class

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Tue Nov 22 2016 Nick Miller <nick.miller@onyxpoint.com> - 5.0.1-0
+- Reset max_consecutive_per_class in openldap::slapo::ppolicy to 3
+
 * Mon Nov 21 2016 Chris Tessmer <chris.tessmer@onyxpoint.com> - 5.0.0-0
 - Updated to compliance_markup version 2
 

--- a/manifests/slapo/ppolicy.pp
+++ b/manifests/slapo/ppolicy.pp
@@ -51,7 +51,7 @@
 #
 # [*max_consecutive_per_class*]
 # Type: Integer
-# Default: '2'
+# Default: '3'
 #   The maximum number of characters from any character class that can exist in
 #   a row.
 #
@@ -70,7 +70,7 @@ class openldap::slapo::ppolicy (
     $min_lower = '0',
     $min_digit = '0',
     $min_punct = '0',
-    $max_consecutive_per_class = '2'
+    $max_consecutive_per_class = '3'
 ) {
   include '::openldap::server::dynamic_includes'
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-openldap",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "author": "SIMP Team",
   "summary": "Manages OpenLDAP and related security bindings",
   "license": "Apache-2.0",


### PR DESCRIPTION
Reset max_consecutive_per_class in openldap::slapo::ppolicy to 3

SIMP-2118 #close

Change-Id: I1c11e03ae750a1a3d8643b548520ff97885333f2